### PR TITLE
feat: add sign-in links for alternative authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ For development, build and run the backend and frontend locally from source.
 
    - `DATABASE_URL`: Connection string for the PostgreSQL database.
 
+   - `MAGIC_LINK_WEBHOOK_URL` _(optional)_: Enables the email (magic link) authentication method. When set, the server `POST`s a JSON payload to this URL whenever a sign-in link is requested:
+
+     ```json
+     {
+       "email": "user@example.com",
+       "name": "User Name",
+       "login_url": "https://your-app/app?magic_token=<token>"
+     }
+     ```
+
+     If this variable is not set, the email auth method is disabled and the `/api/auth/email/*` endpoints return an error.
+
+   - `SESSION_SECRET` _(optional)_: Secret used to sign session cookies. A random value is generated on startup if not provided — set this explicitly in production to preserve sessions across restarts.
+
 3. **Database setup:**
    - Configure the `DATABASE_URL` in the `.env` file as shown above.
 
@@ -204,6 +218,56 @@ The project uses Testcontainers for integration testing with PostgreSQL.
    go test ./... -v
    ```
 
+## Authentication
+
+The app supports two sign-in methods, which can be used simultaneously.
+
+### Passkeys (WebAuthn)
+
+The default method. A user account is created via an **assignment link** — a short-lived, single-use URL that ties a device's passkey to a specific user. Assignment links can be created by an admin or by the user themselves from the account page.
+
+### Email (Magic Links)
+
+Enabled by setting `MAGIC_LINK_WEBHOOK_URL`. When a user requests a sign-in link, the server dispatches a `POST` to the webhook with the login URL; no email server is required — use any HTTP endpoint (e.g. a transactional email provider's API or an automation webhook).
+
+Flow:
+1. `POST /api/auth/email/login/request` — client submits `{"email": "..."}`. Always returns `200`; does not reveal whether the address is registered.
+2. The webhook receives `{"email", "name", "login_url"}` and sends the link to the user.
+3. User clicks the link; the frontend extracts `?magic_token=` from the URL and calls `POST /api/auth/email/login/consume` with `{"token": "..."}` to establish a session.
+
+Tokens expire after **10 minutes** and are single-use. A **30-second cooldown** per user prevents request flooding.
+
+#### Email registration via assignment link
+
+An assignment link can also be used to register an email address instead of a passkey, allowing users without a WebAuthn-capable device to register:
+
+`POST /api/auth/email/register` — body: `{"assignment_token": "...", "email": "..."}`.
+
+### Auth API reference
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/auth/session` | — | Current session info |
+| `POST` | `/api/auth/logout` | — | Clear session cookie |
+| `GET` | `/api/auth/features` | — | Feature flags (e.g. `magic_links_enabled`) |
+| `POST` | `/api/auth/register/begin` | — | Begin passkey registration (requires assignment token) |
+| `POST` | `/api/auth/register/finish` | — | Complete passkey registration |
+| `POST` | `/api/auth/login/begin` | — | Begin passkey login |
+| `POST` | `/api/auth/login/finish` | — | Complete passkey login |
+| `POST` | `/api/auth/email/register` | — | Register email via assignment link |
+| `POST` | `/api/auth/email/login/request` | — | Request magic link |
+| `POST` | `/api/auth/email/login/consume` | — | Consume magic link token, establish session |
+| `GET` | `/api/auth/self/assignment-link` | ✓ | Get current user's active assignment link |
+| `POST` | `/api/auth/self/assignment-link` | ✓ | Create assignment link for current user |
+| `DELETE` | `/api/auth/self/assignment-link` | ✓ | Revoke current user's assignment link |
+| `GET` | `/api/auth/self/passkeys` | ✓ | List current user's passkeys |
+| `POST` | `/api/auth/self/passkeys/:credential_id/revoke` | ✓ | Revoke a passkey |
+| `GET` | `/api/auth/self/emails` | ✓ | List current user's registered emails |
+| `POST` | `/api/auth/self/emails` | ✓ | Add an email |
+| `POST` | `/api/auth/self/emails/:id/remove` | ✓ | Remove an email |
+
+Admin endpoints follow the same pattern under `/api/auth/admin/users/:user_id/`.
+
 ## Usage of SQLC
 
 - SQLC reads SQL queries from `database/query.sql` and generates Go code for type-safe database access.
@@ -212,13 +276,15 @@ The project uses Testcontainers for integration testing with PostgreSQL.
 
 ## Project Structure
 
-- `main.go` - Entry point for the Go backend
-- `api/` - API routes and handlers
-- `lib/database/` - Database models, query code, and wrappers
-- `client/` - Frontend (Svelte + Bun)
-  - `src/` - Main source code for the frontend
-    - `lib/` - Shared frontend utilities and components
-      - `components/` - Reusable Svelte components (UI, forms, etc.)
-  - `public/` - Static assets served by the frontend
-- `database/` - Database migrations (PostgreSQL) and data storage
-- `build/` - Compiled binaries and static build outputs
+- `main.go` — Entry point for the Go backend
+- `api/` — API routes and handlers
+  - `auth/` — Authentication sub-packages (passkeys, emails, assignmentlinks, bootstrap)
+  - `middleware/` — Session parsing and role enforcement
+- `lib/` — Business logic and shared helpers (no HTTP dependencies)
+  - `auth/` — Session, passkey, magic link, and response-mapping logic
+  - `database/` — sqlc-generated models and query wrappers
+- `client/` — Frontend (Svelte 5 + Bun)
+  - `src/lib/` — Shared utilities and components
+  - `src/views/` — Page-level Svelte views
+- `database/` — SQL migrations and query definitions
+- `build/` — Compiled binaries and static build outputs

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The default method. A user account is created via an **assignment link** — a s
 Enabled by setting `MAGIC_LINK_WEBHOOK_URL`. When a user requests a sign-in link, the server dispatches a `POST` to the webhook with the login URL; no email server is required — use any HTTP endpoint (e.g. a transactional email provider's API or an automation webhook).
 
 Flow:
+
 1. `POST /api/auth/email/login/request` — client submits `{"email": "..."}`. Always returns `200`; does not reveal whether the address is registered.
 2. The webhook receives `{"email", "name", "login_url"}` and sends the link to the user.
 3. User clicks the link; the frontend extracts `?magic_token=` from the URL and calls `POST /api/auth/email/login/consume` with `{"token": "..."}` to establish a session.
@@ -245,26 +246,26 @@ An assignment link can also be used to register an email address instead of a pa
 
 ### Auth API reference
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| `GET` | `/api/auth/session` | — | Current session info |
-| `POST` | `/api/auth/logout` | — | Clear session cookie |
-| `GET` | `/api/auth/features` | — | Feature flags (e.g. `magic_links_enabled`) |
-| `POST` | `/api/auth/register/begin` | — | Begin passkey registration (requires assignment token) |
-| `POST` | `/api/auth/register/finish` | — | Complete passkey registration |
-| `POST` | `/api/auth/login/begin` | — | Begin passkey login |
-| `POST` | `/api/auth/login/finish` | — | Complete passkey login |
-| `POST` | `/api/auth/email/register` | — | Register email via assignment link |
-| `POST` | `/api/auth/email/login/request` | — | Request magic link |
-| `POST` | `/api/auth/email/login/consume` | — | Consume magic link token, establish session |
-| `GET` | `/api/auth/self/assignment-link` | ✓ | Get current user's active assignment link |
-| `POST` | `/api/auth/self/assignment-link` | ✓ | Create assignment link for current user |
-| `DELETE` | `/api/auth/self/assignment-link` | ✓ | Revoke current user's assignment link |
-| `GET` | `/api/auth/self/passkeys` | ✓ | List current user's passkeys |
-| `POST` | `/api/auth/self/passkeys/:credential_id/revoke` | ✓ | Revoke a passkey |
-| `GET` | `/api/auth/self/emails` | ✓ | List current user's registered emails |
-| `POST` | `/api/auth/self/emails` | ✓ | Add an email |
-| `POST` | `/api/auth/self/emails/:id/remove` | ✓ | Remove an email |
+| Method   | Path                                            | Auth | Description                                            |
+| -------- | ----------------------------------------------- | ---- | ------------------------------------------------------ |
+| `GET`    | `/api/auth/session`                             | —    | Current session info                                   |
+| `POST`   | `/api/auth/logout`                              | —    | Clear session cookie                                   |
+| `GET`    | `/api/auth/features`                            | —    | Feature flags (e.g. `magic_links_enabled`)             |
+| `POST`   | `/api/auth/register/begin`                      | —    | Begin passkey registration (requires assignment token) |
+| `POST`   | `/api/auth/register/finish`                     | —    | Complete passkey registration                          |
+| `POST`   | `/api/auth/login/begin`                         | —    | Begin passkey login                                    |
+| `POST`   | `/api/auth/login/finish`                        | —    | Complete passkey login                                 |
+| `POST`   | `/api/auth/email/register`                      | —    | Register email via assignment link                     |
+| `POST`   | `/api/auth/email/login/request`                 | —    | Request magic link                                     |
+| `POST`   | `/api/auth/email/login/consume`                 | —    | Consume magic link token, establish session            |
+| `GET`    | `/api/auth/self/assignment-link`                | ✓    | Get current user's active assignment link              |
+| `POST`   | `/api/auth/self/assignment-link`                | ✓    | Create assignment link for current user                |
+| `DELETE` | `/api/auth/self/assignment-link`                | ✓    | Revoke current user's assignment link                  |
+| `GET`    | `/api/auth/self/passkeys`                       | ✓    | List current user's passkeys                           |
+| `POST`   | `/api/auth/self/passkeys/:credential_id/revoke` | ✓    | Revoke a passkey                                       |
+| `GET`    | `/api/auth/self/emails`                         | ✓    | List current user's registered emails                  |
+| `POST`   | `/api/auth/self/emails`                         | ✓    | Add an email                                           |
+| `POST`   | `/api/auth/self/emails/:id/remove`              | ✓    | Remove an email                                        |
 
 Admin endpoints follow the same pattern under `/api/auth/admin/users/:user_id/`.
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,6 @@ docker compose pull app
 docker compose up -d app
 ```
 
-### Notes
-
-- Change the PostgreSQL password before deploying.
-- Do not set `DEV=true` in production.
-
 ## Development Guide
 
 For development, build and run the backend and frontend locally from source.
@@ -217,58 +212,6 @@ The project uses Testcontainers for integration testing with PostgreSQL.
    ```powershell
    go test ./... -v
    ```
-
-## Authentication
-
-The app supports two sign-in methods, which can be used simultaneously.
-
-### Passkeys (WebAuthn)
-
-The default method. A user account is created via an **assignment link** — a short-lived, single-use URL that ties a device's passkey to a specific user. Assignment links can be created by an admin or by the user themselves from the account page.
-
-### Email (Magic Links)
-
-Enabled by setting `MAGIC_LINK_WEBHOOK_URL`. When a user requests a sign-in link, the server dispatches a `POST` to the webhook with the login URL; no email server is required — use any HTTP endpoint (e.g. a transactional email provider's API or an automation webhook).
-
-Flow:
-
-1. `POST /api/auth/email/login/request` — client submits `{"email": "..."}`. Always returns `200`; does not reveal whether the address is registered.
-2. The webhook receives `{"email", "name", "login_url"}` and sends the link to the user.
-3. User clicks the link; the frontend extracts `?magic_token=` from the URL and calls `POST /api/auth/email/login/consume` with `{"token": "..."}` to establish a session.
-
-Tokens expire after **10 minutes** and are single-use. A **30-second cooldown** per user prevents request flooding.
-
-#### Email registration via assignment link
-
-An assignment link can also be used to register an email address instead of a passkey, allowing users without a WebAuthn-capable device to register:
-
-`POST /api/auth/email/register` — body: `{"assignment_token": "...", "email": "..."}`.
-
-### Auth API reference
-
-| Method   | Path                                            | Auth | Description                                            |
-| -------- | ----------------------------------------------- | ---- | ------------------------------------------------------ |
-| `GET`    | `/api/auth/session`                             | —    | Current session info                                   |
-| `POST`   | `/api/auth/logout`                              | —    | Clear session cookie                                   |
-| `GET`    | `/api/auth/features`                            | —    | Feature flags (e.g. `magic_links_enabled`)             |
-| `POST`   | `/api/auth/register/begin`                      | —    | Begin passkey registration (requires assignment token) |
-| `POST`   | `/api/auth/register/finish`                     | —    | Complete passkey registration                          |
-| `POST`   | `/api/auth/login/begin`                         | —    | Begin passkey login                                    |
-| `POST`   | `/api/auth/login/finish`                        | —    | Complete passkey login                                 |
-| `POST`   | `/api/auth/email/register`                      | —    | Register email via assignment link                     |
-| `POST`   | `/api/auth/email/login/request`                 | —    | Request magic link                                     |
-| `POST`   | `/api/auth/email/login/consume`                 | —    | Consume magic link token, establish session            |
-| `GET`    | `/api/auth/self/assignment-link`                | ✓    | Get current user's active assignment link              |
-| `POST`   | `/api/auth/self/assignment-link`                | ✓    | Create assignment link for current user                |
-| `DELETE` | `/api/auth/self/assignment-link`                | ✓    | Revoke current user's assignment link                  |
-| `GET`    | `/api/auth/self/passkeys`                       | ✓    | List current user's passkeys                           |
-| `POST`   | `/api/auth/self/passkeys/:credential_id/revoke` | ✓    | Revoke a passkey                                       |
-| `GET`    | `/api/auth/self/emails`                         | ✓    | List current user's registered emails                  |
-| `POST`   | `/api/auth/self/emails`                         | ✓    | Add an email                                           |
-| `POST`   | `/api/auth/self/emails/:id/remove`              | ✓    | Remove an email                                        |
-
-Admin endpoints follow the same pattern under `/api/auth/admin/users/:user_id/`.
-
 ## Usage of SQLC
 
 - SQLC reads SQL queries from `database/query.sql` and generates Go code for type-safe database access.

--- a/api/auth/assignmentlinks/admin.go
+++ b/api/auth/assignmentlinks/admin.go
@@ -1,0 +1,114 @@
+package assignmentlinks
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"reesource-tracker/api/middleware"
+	libauth "reesource-tracker/lib/auth"
+	"reesource-tracker/lib/database"
+	id_helper "reesource-tracker/lib/id_helper"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AdminRoutes registers admin-only assignment link and audit log endpoints
+// under the provided /admin group.
+func AdminRoutes(admin *gin.RouterGroup) {
+	admin.GET("/users/:user_id/assignment-link", adminGetActiveAssignmentLink)
+	admin.POST("/users/:user_id/assignment-link", adminCreateAssignmentLink)
+	admin.DELETE("/users/:user_id/assignment-link", middleware.RequireConfirmedAction(), adminDeleteActiveAssignmentLink)
+	admin.POST("/assignment-links/:link_id/revoke", middleware.RequireConfirmedAction(), adminRevokeAssignmentLink)
+	admin.GET("/audit-logs", adminListAuditLogs)
+}
+
+func adminCreateAssignmentLink(c *gin.Context) {
+	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	actor, _ := middleware.CurrentUserID(c)
+	row, rawToken, err := libauth.CreateStandardAssignmentLinkForUser(c, uid, actor)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, libauth.AssignmentLinkMap(c.Request, row, rawToken))
+}
+
+func adminGetActiveAssignmentLink(c *gin.Context) {
+	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	row, err := database.Connection.GetActiveStandardAssignmentLinkByUserID(c, uid)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			c.JSON(http.StatusOK, gin.H{"has_active_link": false})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	res := libauth.AssignmentLinkMap(c.Request, row, "")
+	res["has_active_link"] = true
+	c.JSON(http.StatusOK, res)
+}
+
+func adminDeleteActiveAssignmentLink(c *gin.Context) {
+	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	revoked, err := database.Connection.RevokeActiveStandardAssignmentLinksForUser(c, uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if revoked > 0 {
+		actor, _ := middleware.CurrentUserID(c)
+		_ = libauth.AuditLog(c, &actor, "assignment_link_revoked", "user", c.Param("user_id"), map[string]any{"revoked_count": revoked})
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "revoked_count": revoked})
+}
+
+func adminRevokeAssignmentLink(c *gin.Context) {
+	linkID, err := strconv.ParseInt(c.Param("link_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid link_id"})
+		return
+	}
+	if err := database.Connection.RevokeAssignmentLink(c, linkID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	actor, _ := middleware.CurrentUserID(c)
+	_ = libauth.AuditLog(c, &actor, "assignment_link_revoked", "assignment_link", c.Param("link_id"), map[string]any{})
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func adminListAuditLogs(c *gin.Context) {
+	limit := int32(100)
+	offset := int32(0)
+	if s := c.Query("limit"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil && v > 0 {
+			limit = int32(v)
+		}
+	}
+	if s := c.Query("offset"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil && v >= 0 {
+			offset = int32(v)
+		}
+	}
+	rows, err := database.Connection.ListAuditLogs(c, database.ListAuditLogsParams{Limit: limit, Offset: offset})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}

--- a/api/auth/assignmentlinks/self.go
+++ b/api/auth/assignmentlinks/self.go
@@ -1,0 +1,60 @@
+package assignmentlinks
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+
+	"reesource-tracker/api/middleware"
+	libauth "reesource-tracker/lib/auth"
+	"reesource-tracker/lib/database"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SelfRoutes registers authenticated routes for managing the current user's
+// assignment link under the provided /self group.
+func SelfRoutes(self *gin.RouterGroup) {
+	self.POST("/assignment-link", createSelfAssignmentLink)
+	self.GET("/assignment-link", getSelfAssignmentLink)
+	self.DELETE("/assignment-link", middleware.RequireConfirmedAction(), deleteSelfAssignmentLink)
+}
+
+func createSelfAssignmentLink(c *gin.Context) {
+	userID, _ := middleware.CurrentUserID(c)
+	row, rawToken, err := libauth.CreateStandardAssignmentLinkForUser(c, userID, userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, libauth.AssignmentLinkMap(c.Request, row, rawToken))
+}
+
+func getSelfAssignmentLink(c *gin.Context) {
+	userID, _ := middleware.CurrentUserID(c)
+	row, err := database.Connection.GetActiveStandardAssignmentLinkByUserID(c, userID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			c.JSON(http.StatusOK, gin.H{"has_active_link": false})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	res := libauth.AssignmentLinkMap(c.Request, row, "")
+	res["has_active_link"] = true
+	c.JSON(http.StatusOK, res)
+}
+
+func deleteSelfAssignmentLink(c *gin.Context) {
+	userID, _ := middleware.CurrentUserID(c)
+	revoked, err := database.Connection.RevokeActiveStandardAssignmentLinksForUser(c, userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if revoked > 0 {
+		_ = libauth.AuditLog(c, &userID, "assignment_link_revoked", "user", libauth.IDOrEmpty(userID), map[string]any{"revoked_count": revoked, "scope": "self"})
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "revoked_count": revoked})
+}

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -19,87 +19,87 @@ import (
 type RuntimeConfig = libauth.RuntimeConfig
 
 func Initialize(ctx context.Context, cfg RuntimeConfig) error {
-secret := os.Getenv("SESSION_SECRET")
-if secret == "" {
-generated, err := libauth.RandomHex(32)
-if err != nil {
-return err
-}
-secret = generated
-}
-middleware.SetCookieSecret([]byte(secret))
+	secret := os.Getenv("SESSION_SECRET")
+	if secret == "" {
+		generated, err := libauth.RandomHex(32)
+		if err != nil {
+			return err
+		}
+		secret = generated
+	}
+	middleware.SetCookieSecret([]byte(secret))
 
-if _, _, _, err := libauth.EnsureBootstrapState(ctx); err != nil {
-return err
-}
-libauth.RunAuditRetentionCleanup(ctx, cfg)
-return nil
+	if _, _, _, err := libauth.EnsureBootstrapState(ctx); err != nil {
+		return err
+	}
+	libauth.RunAuditRetentionCleanup(ctx, cfg)
+	return nil
 }
 
 func Routes(route *gin.RouterGroup) {
-authRoutes := route.Group("/auth")
+	authRoutes := route.Group("/auth")
 
-// Session + feature discovery (not method-specific).
-authRoutes.GET("/session", getSession)
-authRoutes.POST("/logout", logout)
-authRoutes.GET("/features", getAuthFeatures)
+	// Session + feature discovery (not method-specific).
+	authRoutes.GET("/session", getSession)
+	authRoutes.POST("/logout", logout)
+	authRoutes.GET("/features", getAuthFeatures)
 
-// Bootstrap flow (pre-auth account creation).
-authbootstrap.Routes(authRoutes)
+	// Bootstrap flow (pre-auth account creation).
+	authbootstrap.Routes(authRoutes)
 
-// Each auth method registers its own public sign-in routes and receives
-// the same /self and /admin sub-groups for credential management.
-// Adding a new method: implement libauth.AuthMethod and add it here.
-self := authRoutes.Group("/self")
-self.Use(middleware.RequireAuthenticated())
+	// Each auth method registers its own public sign-in routes and receives
+	// the same /self and /admin sub-groups for credential management.
+	// Adding a new method: implement libauth.AuthMethod and add it here.
+	self := authRoutes.Group("/self")
+	self.Use(middleware.RequireAuthenticated())
 
-admin := authRoutes.Group("/admin")
-admin.Use(middleware.RequireAuthenticated(), middleware.RequireRole(libauth.RoleAdmin))
+	admin := authRoutes.Group("/admin")
+	admin.Use(middleware.RequireAuthenticated(), middleware.RequireRole(libauth.RoleAdmin))
 
-// Passkey auth method.
-authpasskeys.Routes(authRoutes)
-authpasskeys.SelfRoutes(self)
-authpasskeys.AdminRoutes(admin)
+	// Passkey auth method.
+	authpasskeys.Routes(authRoutes)
+	authpasskeys.SelfRoutes(self)
+	authpasskeys.AdminRoutes(admin)
 	// Assignment links (shared mechanism for all auth methods).
 	authassignmentlinks.SelfRoutes(self)
 	authassignmentlinks.AdminRoutes(admin)
-// Email (magic-link) auth method.
-authemails.RegisterRoutes(authRoutes)
-authemails.LoginRoutes(authRoutes)
-authemails.SelfRoutes(self)
-authemails.AdminRoutes(admin)
+	// Email (magic-link) auth method.
+	authemails.RegisterRoutes(authRoutes)
+	authemails.LoginRoutes(authRoutes)
+	authemails.SelfRoutes(self)
+	authemails.AdminRoutes(admin)
 }
 
 func getSession(c *gin.Context) {
-if middleware.AuthBypassed() {
-c.JSON(http.StatusOK, gin.H{"authenticated": false})
-return
-}
-userID, err := middleware.ParseSessionCookie(c)
-if err != nil {
-c.JSON(http.StatusOK, gin.H{"authenticated": false})
-return
-}
-user, err := database.Connection.GetUserByID(c, userID)
-if err != nil {
-c.JSON(http.StatusOK, gin.H{"authenticated": false})
-return
-}
-roles, _ := database.Connection.ListUserRoles(c, userID)
-c.JSON(http.StatusOK, gin.H{
-"authenticated": true,
-"user":          gin.H{"ID": user.ID, "Name": user.Name},
-"roles":         roles,
-})
+	if middleware.AuthBypassed() {
+		c.JSON(http.StatusOK, gin.H{"authenticated": false})
+		return
+	}
+	userID, err := middleware.ParseSessionCookie(c)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"authenticated": false})
+		return
+	}
+	user, err := database.Connection.GetUserByID(c, userID)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"authenticated": false})
+		return
+	}
+	roles, _ := database.Connection.ListUserRoles(c, userID)
+	c.JSON(http.StatusOK, gin.H{
+		"authenticated": true,
+		"user":          gin.H{"ID": user.ID, "Name": user.Name},
+		"roles":         roles,
+	})
 }
 
 func logout(c *gin.Context) {
-c.SetCookie(middleware.SessionCookieName, "", -1, "/", "", false, true)
-c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	c.SetCookie(middleware.SessionCookieName, "", -1, "/", "", false, true)
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
 func getAuthFeatures(c *gin.Context) {
-c.JSON(http.StatusOK, gin.H{
-"magic_links_enabled": libauth.MagicLinkEnabled(),
-})
+	c.JSON(http.StatusOK, gin.H{
+		"magic_links_enabled": libauth.MagicLinkEnabled(),
+	})
 }

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -1,21 +1,17 @@
-package auth
+﻿package auth
 
 import (
-	"bytes"
 	"context"
-	"database/sql"
-	"encoding/hex"
-	"errors"
-	"io"
 	"net/http"
-	"net/url"
 	"os"
-	"strconv"
 
+	authassignmentlinks "reesource-tracker/api/auth/assignmentlinks"
+	authbootstrap "reesource-tracker/api/auth/bootstrap"
+	authemails "reesource-tracker/api/auth/emails"
+	authpasskeys "reesource-tracker/api/auth/passkeys"
 	"reesource-tracker/api/middleware"
 	libauth "reesource-tracker/lib/auth"
 	"reesource-tracker/lib/database"
-	id_helper "reesource-tracker/lib/id_helper"
 
 	"github.com/gin-gonic/gin"
 )
@@ -23,591 +19,87 @@ import (
 type RuntimeConfig = libauth.RuntimeConfig
 
 func Initialize(ctx context.Context, cfg RuntimeConfig) error {
-	secret := os.Getenv("SESSION_SECRET")
-	if secret == "" {
-		generated, err := libauth.RandomHex(32)
-		if err != nil {
-			return err
-		}
-		secret = generated
-	}
-	middleware.SetCookieSecret([]byte(secret))
+secret := os.Getenv("SESSION_SECRET")
+if secret == "" {
+generated, err := libauth.RandomHex(32)
+if err != nil {
+return err
+}
+secret = generated
+}
+middleware.SetCookieSecret([]byte(secret))
 
-	if _, _, _, err := libauth.EnsureBootstrapState(ctx); err != nil {
-		return err
-	}
-	libauth.RunAuditRetentionCleanup(ctx, cfg)
-	return nil
+if _, _, _, err := libauth.EnsureBootstrapState(ctx); err != nil {
+return err
+}
+libauth.RunAuditRetentionCleanup(ctx, cfg)
+return nil
 }
 
 func Routes(route *gin.RouterGroup) {
-	authRoutes := route.Group("/auth")
-	authRoutes.GET("/bootstrap-status", getBootstrapStatus)
-	authRoutes.GET("/bootstrap-options", getBootstrapOptions)
-	authRoutes.POST("/bootstrap/select-user", bootstrapSelectUser)
-	authRoutes.POST("/bootstrap/create-user", bootstrapCreateUser)
-	authRoutes.GET("/session", getSession)
-	authRoutes.POST("/logout", logout)
+authRoutes := route.Group("/auth")
 
-	authRoutes.POST("/register/begin", beginRegistration)
-	authRoutes.POST("/register/finish", finishRegistration)
-	authRoutes.POST("/login/begin", beginLogin)
-	authRoutes.POST("/login/finish", finishLogin)
+// Session + feature discovery (not method-specific).
+authRoutes.GET("/session", getSession)
+authRoutes.POST("/logout", logout)
+authRoutes.GET("/features", getAuthFeatures)
 
-	self := authRoutes.Group("/self")
-	self.Use(middleware.RequireAuthenticated())
-	self.POST("/assignment-link", createSelfAssignmentLink)
-	self.GET("/assignment-link", getSelfAssignmentLink)
-	self.DELETE("/assignment-link", middleware.RequireConfirmedAction(), deleteSelfAssignmentLink)
-	self.GET("/passkeys", listSelfPasskeys)
-	self.POST("/passkeys/:credential_id/revoke", middleware.RequireConfirmedAction(), revokeSelfPasskey)
+// Bootstrap flow (pre-auth account creation).
+authbootstrap.Routes(authRoutes)
 
-	admin := authRoutes.Group("/admin")
-	admin.Use(middleware.RequireAuthenticated(), middleware.RequireRole(libauth.RoleAdmin))
-	admin.GET("/users/:user_id/assignment-link", adminGetActiveAssignmentLink)
-	admin.POST("/users/:user_id/assignment-link", adminCreateAssignmentLink)
-	admin.DELETE("/users/:user_id/assignment-link", middleware.RequireConfirmedAction(), adminDeleteActiveAssignmentLink)
-	admin.GET("/users/:user_id/passkeys", adminListUserPasskeys)
-	admin.POST("/assignment-links/:link_id/revoke", middleware.RequireConfirmedAction(), adminRevokeAssignmentLink)
-	admin.POST("/users/:user_id/passkeys/revoke-all", middleware.RequireConfirmedAction(), adminRevokeAllPasskeys)
-	admin.POST("/passkeys/:credential_id/revoke", middleware.RequireConfirmedAction(), adminRevokePasskey)
-	admin.GET("/audit-logs", adminListAuditLogs)
-}
+// Each auth method registers its own public sign-in routes and receives
+// the same /self and /admin sub-groups for credential management.
+// Adding a new method: implement libauth.AuthMethod and add it here.
+self := authRoutes.Group("/self")
+self.Use(middleware.RequireAuthenticated())
 
-func getBootstrapStatus(c *gin.Context) {
-	required, token, userID, err := libauth.EnsureBootstrapState(c)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
+admin := authRoutes.Group("/admin")
+admin.Use(middleware.RequireAuthenticated(), middleware.RequireRole(libauth.RoleAdmin))
 
-	c.JSON(http.StatusOK, gin.H{
-		"bootstrap_required": required,
-		"assignment_token":   token,
-		"user_id":            userID,
-		"assignment_url":     "/app?assignment_token=" + token,
-	})
-}
-
-func getBootstrapOptions(c *gin.Context) {
-	required, token, userID, err := libauth.EnsureBootstrapState(c)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	users, err := libauth.ListBootstrapUserOptions(c)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{
-		"bootstrap_required": required,
-		"assignment_token":   token,
-		"user_id":            userID,
-		"users":              users,
-	})
-}
-
-func bootstrapSelectUser(c *gin.Context) {
-	var req struct {
-		UserID string `json:"user_id"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil || req.UserID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id is required"})
-		return
-	}
-	required, _, _, err := libauth.EnsureBootstrapState(c)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if !required {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "bootstrap flow is not active"})
-		return
-	}
-
-	uid, msg, ok := id_helper.MustParseAndMarshalUUID(req.UserID)
-	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-	token, selectedUserID, err := libauth.SelectBootstrapUser(c, uid)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"assignment_token": token, "user_id": selectedUserID})
-}
-
-func bootstrapCreateUser(c *gin.Context) {
-	var req struct {
-		Name string `json:"name"`
-	}
-	_ = c.ShouldBindJSON(&req)
-	required, _, _, err := libauth.EnsureBootstrapState(c)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if !required {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "bootstrap flow is not active"})
-		return
-	}
-	token, selectedUserID, err := libauth.CreateBootstrapUserAndSelect(c, req.Name)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"assignment_token": token, "user_id": selectedUserID})
-}
-
-func beginRegistration(c *gin.Context) {
-	var req struct {
-		AssignmentToken string `json:"assignment_token"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	res, err := libauth.BeginRegistration(c, req.AssignmentToken)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"challenge_token": res.ChallengeToken,
-		"challenge":       res.Challenge,
-		"user_id":         res.UserID,
-		"user_name":       res.UserName,
-	})
-}
-
-func finishRegistration(c *gin.Context) {
-	var req struct {
-		ChallengeToken string   `json:"challenge_token"`
-		Challenge      string   `json:"challenge"`
-		CredentialID   string   `json:"credential_id"`
-		PublicKey      string   `json:"public_key"`
-		Label          string   `json:"label"`
-		Transports     []string `json:"transports"`
-		ClientDataJSON string   `json:"client_data_json"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	credentialID, err := libauth.DecodeBase64(req.CredentialID)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid credential_id"})
-		return
-	}
-	userID, err := libauth.FinishRegistration(c, libauth.FinishRegistrationInput{
-		ChallengeToken: req.ChallengeToken,
-		Challenge:      req.Challenge,
-		CredentialID:   req.CredentialID,
-		PublicKey:      req.PublicKey,
-		Label:          req.Label,
-		Transports:     req.Transports,
-		ClientDataJSON: req.ClientDataJSON,
-	})
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	if err := middleware.SetSessionCookieWithCredential(c, userID, credentialID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
-}
-
-func beginLogin(c *gin.Context) {
-	var req struct {
-		UserID string `json:"user_id"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil && err != io.EOF {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	res, err := libauth.BeginLogin(c, req.UserID)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"challenge_token": res.ChallengeToken, "challenge": res.Challenge})
-}
-
-func finishLogin(c *gin.Context) {
-	var req struct {
-		ChallengeToken    string `json:"challenge_token"`
-		Challenge         string `json:"challenge"`
-		CredentialID      string `json:"credential_id"`
-		SignCounter       int64  `json:"sign_counter"`
-		ClientDataJSON    string `json:"client_data_json"`
-		AuthenticatorData string `json:"authenticator_data"`
-		Signature         string `json:"signature"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	credentialID, err := libauth.DecodeBase64(req.CredentialID)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid credential_id"})
-		return
-	}
-	userID, err := libauth.FinishLogin(c, libauth.FinishLoginInput{
-		ChallengeToken:    req.ChallengeToken,
-		Challenge:         req.Challenge,
-		CredentialID:      req.CredentialID,
-		SignCounter:       req.SignCounter,
-		ClientDataJSON:    req.ClientDataJSON,
-		AuthenticatorData: req.AuthenticatorData,
-		Signature:         req.Signature,
-	})
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	if err := middleware.SetSessionCookieWithCredential(c, userID, credentialID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+// Passkey auth method.
+authpasskeys.Routes(authRoutes)
+authpasskeys.SelfRoutes(self)
+authpasskeys.AdminRoutes(admin)
+	// Assignment links (shared mechanism for all auth methods).
+	authassignmentlinks.SelfRoutes(self)
+	authassignmentlinks.AdminRoutes(admin)
+// Email (magic-link) auth method.
+authemails.RegisterRoutes(authRoutes)
+authemails.LoginRoutes(authRoutes)
+authemails.SelfRoutes(self)
+authemails.AdminRoutes(admin)
 }
 
 func getSession(c *gin.Context) {
-	if middleware.AuthBypassed() {
-		c.JSON(http.StatusOK, gin.H{"authenticated": false})
-		return
-	}
-
-	userID, err := middleware.ParseSessionCookie(c)
-	if err != nil {
-		c.JSON(http.StatusOK, gin.H{"authenticated": false})
-		return
-	}
-	user, err := database.Connection.GetUserByID(c, userID)
-	if err != nil {
-		c.JSON(http.StatusOK, gin.H{"authenticated": false})
-		return
-	}
-	roles, _ := database.Connection.ListUserRoles(c, userID)
-	c.JSON(http.StatusOK, gin.H{
-		"authenticated": true,
-		"user":          gin.H{"ID": user.ID, "Name": user.Name},
-		"roles":         roles,
-	})
+if middleware.AuthBypassed() {
+c.JSON(http.StatusOK, gin.H{"authenticated": false})
+return
+}
+userID, err := middleware.ParseSessionCookie(c)
+if err != nil {
+c.JSON(http.StatusOK, gin.H{"authenticated": false})
+return
+}
+user, err := database.Connection.GetUserByID(c, userID)
+if err != nil {
+c.JSON(http.StatusOK, gin.H{"authenticated": false})
+return
+}
+roles, _ := database.Connection.ListUserRoles(c, userID)
+c.JSON(http.StatusOK, gin.H{
+"authenticated": true,
+"user":          gin.H{"ID": user.ID, "Name": user.Name},
+"roles":         roles,
+})
 }
 
 func logout(c *gin.Context) {
-	c.SetCookie(middleware.SessionCookieName, "", -1, "/", "", false, true)
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+c.SetCookie(middleware.SessionCookieName, "", -1, "/", "", false, true)
+c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
-func createSelfAssignmentLink(c *gin.Context) {
-	userID, _ := middleware.CurrentUserID(c)
-	row, rawToken, err := libauth.CreateStandardAssignmentLinkForUser(c, userID, userID)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, assignmentLinkResponse(c, row, rawToken))
+func getAuthFeatures(c *gin.Context) {
+c.JSON(http.StatusOK, gin.H{
+"magic_links_enabled": libauth.MagicLinkEnabled(),
+})
 }
-
-func getSelfAssignmentLink(c *gin.Context) {
-	userID, _ := middleware.CurrentUserID(c)
-	row, err := database.Connection.GetActiveStandardAssignmentLinkByUserID(c, userID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			c.JSON(http.StatusOK, gin.H{"has_active_link": false})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	// The raw token is only available at creation time; we cannot recover it
-	// from the stored hash. Return metadata without the token.
-	res := assignmentLinkResponse(c, row, "")
-	res["has_active_link"] = true
-	c.JSON(http.StatusOK, res)
-}
-
-func deleteSelfAssignmentLink(c *gin.Context) {
-	userID, _ := middleware.CurrentUserID(c)
-	revoked, err := database.Connection.RevokeActiveStandardAssignmentLinksForUser(c, userID)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if revoked > 0 {
-		_ = libauth.AuditLog(c, &userID, "assignment_link_revoked", "user", libauth.IDOrEmpty(userID), map[string]any{"revoked_count": revoked, "scope": "self"})
-	}
-	c.JSON(http.StatusOK, gin.H{"status": "ok", "revoked_count": revoked})
-}
-
-func listSelfPasskeys(c *gin.Context) {
-	userID, _ := middleware.CurrentUserID(c)
-	rows, err := database.Connection.ListPasskeysByUser(c, userID)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	activeCredentialID, _ := middleware.CurrentCredentialID(c)
-	c.JSON(http.StatusOK, passkeyListResponse(rows, activeCredentialID))
-}
-
-func revokeSelfPasskey(c *gin.Context) {
-	userID, _ := middleware.CurrentUserID(c)
-	credentialID, credentialIDHex, err := credentialIDFromParam(c)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid credential_id"})
-		return
-	}
-
-	passkey, err := database.Connection.GetPasskeyByCredentialID(c, credentialID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "passkey not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if !bytes.Equal(passkey.UserID, userID) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-		return
-	}
-
-	activeCredentialID, ok := middleware.CurrentCredentialID(c)
-	if !ok {
-		c.JSON(http.StatusForbidden, gin.H{"error": "reauthentication required before removing passkeys"})
-		return
-	}
-	if bytes.Equal(activeCredentialID, credentialID) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "cannot remove the passkey used by your current session"})
-		return
-	}
-
-	if err := database.Connection.RevokePasskey(c, credentialID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	_ = libauth.AuditLog(c, &userID, "passkey_revoked", "passkey", credentialIDHex, map[string]any{"scope": "self"})
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
-}
-
-func adminCreateAssignmentLink(c *gin.Context) {
-	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
-	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-	actor, _ := middleware.CurrentUserID(c)
-	row, rawToken, err := libauth.CreateStandardAssignmentLinkForUser(c, uid, actor)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, assignmentLinkResponse(c, row, rawToken))
-}
-
-func adminGetActiveAssignmentLink(c *gin.Context) {
-	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
-	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	row, err := database.Connection.GetActiveStandardAssignmentLinkByUserID(c, uid)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			c.JSON(http.StatusOK, gin.H{"has_active_link": false})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	// The raw token is only available at creation time; return metadata only.
-	res := assignmentLinkResponse(c, row, "")
-	res["has_active_link"] = true
-	c.JSON(http.StatusOK, res)
-}
-
-func adminDeleteActiveAssignmentLink(c *gin.Context) {
-	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
-	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	revoked, err := database.Connection.RevokeActiveStandardAssignmentLinksForUser(c, uid)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	if revoked > 0 {
-		actor, _ := middleware.CurrentUserID(c)
-		_ = libauth.AuditLog(c, &actor, "assignment_link_revoked", "user", c.Param("user_id"), map[string]any{"revoked_count": revoked})
-	}
-
-	c.JSON(http.StatusOK, gin.H{"status": "ok", "revoked_count": revoked})
-}
-
-func adminRevokeAssignmentLink(c *gin.Context) {
-	linkID, err := strconv.ParseInt(c.Param("link_id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid link_id"})
-		return
-	}
-	if err := database.Connection.RevokeAssignmentLink(c, linkID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	actor, _ := middleware.CurrentUserID(c)
-	_ = libauth.AuditLog(c, &actor, "assignment_link_revoked", "assignment_link", c.Param("link_id"), map[string]any{})
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
-}
-
-func adminRevokeAllPasskeys(c *gin.Context) {
-	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
-	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-	if err := database.Connection.RevokeAllPasskeysForUser(c, uid); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	actor, _ := middleware.CurrentUserID(c)
-	_ = libauth.AuditLog(c, &actor, "passkeys_revoked_all", "user", c.Param("user_id"), map[string]any{})
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
-}
-
-func adminRevokePasskey(c *gin.Context) {
-	credentialID, credentialIDHex, err := credentialIDFromParam(c)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid credential_id"})
-		return
-	}
-	if err := database.Connection.RevokePasskey(c, credentialID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	actor, _ := middleware.CurrentUserID(c)
-	_ = libauth.AuditLog(c, &actor, "passkey_revoked", "passkey", credentialIDHex, map[string]any{"scope": "admin"})
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
-}
-
-func adminListUserPasskeys(c *gin.Context) {
-	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
-	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
-		return
-	}
-
-	rows, err := database.Connection.ListPasskeysByUser(c, uid)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, passkeyListResponse(rows, nil))
-}
-
-func adminListAuditLogs(c *gin.Context) {
-	limit := int32(100)
-	offset := int32(0)
-	if s := c.Query("limit"); s != "" {
-		if v, err := strconv.Atoi(s); err == nil && v > 0 {
-			limit = int32(v)
-		}
-	}
-	if s := c.Query("offset"); s != "" {
-		if v, err := strconv.Atoi(s); err == nil && v >= 0 {
-			offset = int32(v)
-		}
-	}
-
-	rows, err := database.Connection.ListAuditLogs(c, database.ListAuditLogsParams{Limit: limit, Offset: offset})
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, rows)
-}
-
-// assignmentLinkResponse builds the JSON response for an assignment link.
-// rawToken should be the raw (unhashed) token returned at creation time; pass
-// an empty string for read-only endpoints where the token cannot be recovered
-// from the stored hash.
-func assignmentLinkResponse(c *gin.Context, row database.PasskeyAssignmentLink, rawToken string) gin.H {
-	res := gin.H{
-		"link_id": row.ID,
-	}
-	if rawToken != "" {
-		res["assignment_token"] = rawToken
-		res["assignment_url"] = buildAssignmentURL(c, rawToken)
-	}
-	if row.ExpiresAt.Valid {
-		res["expires_at"] = row.ExpiresAt.Time
-	}
-	return res
-}
-
-func buildAssignmentURL(c *gin.Context, token string) string {
-	scheme := c.GetHeader("X-Forwarded-Proto")
-	if scheme == "" {
-		if c.Request.TLS != nil {
-			scheme = "https"
-		} else {
-			scheme = "http"
-		}
-	}
-	host := c.GetHeader("X-Forwarded-Host")
-	if host == "" {
-		host = c.Request.Host
-	}
-	return scheme + "://" + host + "/app?assignment_token=" + url.QueryEscape(token)
-}
-
-func passkeyListResponse(rows []database.Passkey, activeCredentialID []byte) []gin.H {
-	res := make([]gin.H, 0, len(rows))
-	for _, row := range rows {
-		if row.RevokedAt.Valid {
-			continue
-		}
-		label := ""
-		if row.Label.Valid {
-			label = row.Label.String
-		}
-		res = append(res, gin.H{
-			"credential_id":      hex.EncodeToString(row.CredentialID),
-			"label":              label,
-			"created_at":         row.CreatedAt,
-			"is_current_session": len(activeCredentialID) > 0 && bytes.Equal(row.CredentialID, activeCredentialID),
-		})
-	}
-	return res
-}
-
-func credentialIDFromParam(c *gin.Context) ([]byte, string, error) {
-	credentialIDRaw := c.Param("credential_id")
-	credentialID, err := hex.DecodeString(credentialIDRaw)
-	if err == nil {
-		return credentialID, credentialIDRaw, nil
-	}
-	credentialID, err = libauth.DecodeBase64(credentialIDRaw)
-	if err != nil {
-		return nil, "", err
-	}
-	return credentialID, hex.EncodeToString(credentialID), nil
-}
-

--- a/api/auth/bootstrap/bootstrap.go
+++ b/api/auth/bootstrap/bootstrap.go
@@ -1,0 +1,102 @@
+package bootstrap
+
+import (
+	"net/http"
+
+	libauth "reesource-tracker/lib/auth"
+	id_helper "reesource-tracker/lib/id_helper"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Routes(authRoutes *gin.RouterGroup) {
+	authRoutes.GET("/bootstrap-status", getBootstrapStatus)
+	authRoutes.GET("/bootstrap-options", getBootstrapOptions)
+	authRoutes.POST("/bootstrap/select-user", bootstrapSelectUser)
+	authRoutes.POST("/bootstrap/create-user", bootstrapCreateUser)
+}
+
+func getBootstrapStatus(c *gin.Context) {
+	required, token, userID, err := libauth.EnsureBootstrapState(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"bootstrap_required": required,
+		"assignment_token":   token,
+		"user_id":            userID,
+		"assignment_url":     "/app?assignment_token=" + token,
+	})
+}
+
+func getBootstrapOptions(c *gin.Context) {
+	required, token, userID, err := libauth.EnsureBootstrapState(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	users, err := libauth.ListBootstrapUserOptions(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"bootstrap_required": required,
+		"assignment_token":   token,
+		"user_id":            userID,
+		"users":              users,
+	})
+}
+
+func bootstrapSelectUser(c *gin.Context) {
+	var req struct {
+		UserID string `json:"user_id"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || req.UserID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id is required"})
+		return
+	}
+	required, _, _, err := libauth.EnsureBootstrapState(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if !required {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "bootstrap flow is not active"})
+		return
+	}
+	uid, msg, ok := id_helper.MustParseAndMarshalUUID(req.UserID)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	token, selectedUserID, err := libauth.SelectBootstrapUser(c, uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"assignment_token": token, "user_id": selectedUserID})
+}
+
+func bootstrapCreateUser(c *gin.Context) {
+	var req struct {
+		Name string `json:"name"`
+	}
+	_ = c.ShouldBindJSON(&req)
+	required, _, _, err := libauth.EnsureBootstrapState(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if !required {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "bootstrap flow is not active"})
+		return
+	}
+	token, selectedUserID, err := libauth.CreateBootstrapUserAndSelect(c, req.Name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"assignment_token": token, "user_id": selectedUserID})
+}

--- a/api/auth/emails/emails.go
+++ b/api/auth/emails/emails.go
@@ -1,0 +1,240 @@
+﻿package emails
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"reesource-tracker/api/middleware"
+	libauth "reesource-tracker/lib/auth"
+	"reesource-tracker/lib/database"
+	id_helper "reesource-tracker/lib/id_helper"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes registers the unauthenticated email registration endpoint.
+// This allows an assignment link to be used to add an email address (instead
+// of, or in addition to, a passkey).
+func RegisterRoutes(authRoutes *gin.RouterGroup) {
+	authRoutes.POST("/email/register", registerEmail)
+}
+
+// SelfRoutes registers authenticated routes for the current user.
+func SelfRoutes(self *gin.RouterGroup) {
+	self.GET("/emails", listSelfEmails)
+	self.POST("/emails", addSelfEmail)
+	self.POST("/emails/:id/remove", middleware.RequireConfirmedAction(), removeSelfEmail)
+}
+
+// AdminRoutes registers admin-only email management routes.
+func AdminRoutes(admin *gin.RouterGroup) {
+	admin.GET("/users/:user_id/emails", adminListUserEmails)
+	admin.POST("/users/:user_id/emails", adminAddUserEmail)
+	admin.POST("/users/:user_id/emails/:id/remove", middleware.RequireConfirmedAction(), adminRemoveUserEmail)
+}
+
+// registerEmail adds an email address to the user identified by an assignment
+// link, then consumes the link. It mirrors the passkey registration flow so
+// that the account-setup page can offer either method from the same link.
+func registerEmail(c *gin.Context) {
+	var req struct {
+		AssignmentToken string `json:"assignment_token"`
+		Email           string `json:"email"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || req.AssignmentToken == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "assignment_token is required"})
+		return
+	}
+	if strings.TrimSpace(req.Email) == "" || !strings.Contains(req.Email, "@") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "a valid email is required"})
+		return
+	}
+	email := strings.TrimSpace(req.Email)
+
+	link, err := database.Connection.GetActiveAssignmentLinkByTokenHash(c, libauth.HashToken(req.AssignmentToken))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid or expired assignment link"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := database.Connection.InsertUserEmail(c, database.InsertUserEmailParams{
+		UserID: link.UserID,
+		Email:  email,
+	}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	_ = database.Connection.ConsumeAssignmentLink(c, link.ID)
+
+	if link.Purpose == "bootstrap" {
+		_ = database.Connection.SetUserRole(c, database.SetUserRoleParams{
+			UserID: link.UserID,
+			Role:   libauth.RoleAdmin,
+		})
+	}
+
+	userIDStr := libauth.IDOrEmpty(link.UserID)
+	_ = libauth.AuditLog(c, nil, "email_registered", "user", userIDStr, map[string]any{"email": email})
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func listSelfEmails(c *gin.Context) {
+	userID, _ := middleware.CurrentUserID(c)
+	rows, err := database.Connection.ListUserEmails(c, userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, emailListResponse(rows))
+}
+
+func addSelfEmail(c *gin.Context) {
+	userID, _ := middleware.CurrentUserID(c)
+	var req struct {
+		Email string `json:"email"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.Email) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "email is required"})
+		return
+	}
+	if !strings.Contains(req.Email, "@") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email address"})
+		return
+	}
+	email := strings.TrimSpace(req.Email)
+	if err := database.Connection.InsertUserEmail(c, database.InsertUserEmailParams{UserID: userID, Email: email}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	_ = libauth.AuditLog(c, &userID, "user_email_added", "user", libauth.IDOrEmpty(userID), map[string]any{"email": email})
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func removeSelfEmail(c *gin.Context) {
+	userID, _ := middleware.CurrentUserID(c)
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	// Fetch first to confirm ownership and get the email for audit log.
+	rows, err := database.Connection.ListUserEmails(c, userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	var target string
+	for _, r := range rows {
+		if r.ID == id {
+			target = r.Email
+			break
+		}
+	}
+	if target == "" {
+		c.JSON(http.StatusNotFound, gin.H{"error": "email not found"})
+		return
+	}
+	if err := database.Connection.DeleteUserEmail(c, database.DeleteUserEmailParams{UserID: userID, Email: target}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	_ = libauth.AuditLog(c, &userID, "user_email_removed", "user", libauth.IDOrEmpty(userID), map[string]any{"email": target})
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func adminListUserEmails(c *gin.Context) {
+	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	rows, err := database.Connection.ListUserEmails(c, uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, emailListResponse(rows))
+}
+
+func adminAddUserEmail(c *gin.Context) {
+	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	var req struct {
+		Email string `json:"email"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.Email) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "email is required"})
+		return
+	}
+	if !strings.Contains(req.Email, "@") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email address"})
+		return
+	}
+	email := strings.TrimSpace(req.Email)
+	if err := database.Connection.InsertUserEmail(c, database.InsertUserEmailParams{UserID: uid, Email: email}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	actor, _ := middleware.CurrentUserID(c)
+	_ = libauth.AuditLog(c, &actor, "user_email_added", "user", c.Param("user_id"), map[string]any{"email": email, "scope": "admin"})
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func adminRemoveUserEmail(c *gin.Context) {
+	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	rows, err := database.Connection.ListUserEmails(c, uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	var target string
+	for _, r := range rows {
+		if r.ID == id {
+			target = r.Email
+			break
+		}
+	}
+	if target == "" {
+		c.JSON(http.StatusNotFound, gin.H{"error": "email not found"})
+		return
+	}
+	if err := database.Connection.DeleteUserEmail(c, database.DeleteUserEmailParams{UserID: uid, Email: target}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	actor, _ := middleware.CurrentUserID(c)
+	_ = libauth.AuditLog(c, &actor, "user_email_removed", "user", c.Param("user_id"), map[string]any{"email": target, "scope": "admin"})
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func emailListResponse(rows []database.UserEmail) []gin.H {
+	res := make([]gin.H, 0, len(rows))
+	for _, e := range rows {
+		res = append(res, gin.H{
+			"id":         e.ID,
+			"email":      e.Email,
+			"created_at": e.CreatedAt,
+		})
+	}
+	return res
+}

--- a/api/auth/emails/magic.go
+++ b/api/auth/emails/magic.go
@@ -1,0 +1,84 @@
+package emails
+
+// Magic link sign-in is the authentication flow for the email auth method.
+// A time-limited single-use token is generated and dispatched to the user's
+// registered email address via the configured webhook; the user clicks the link
+// which calls /auth/email/login/consume to establish a session.
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"reesource-tracker/api/middleware"
+	libauth "reesource-tracker/lib/auth"
+
+	"github.com/gin-gonic/gin"
+)
+
+// LoginRoutes registers the unauthenticated magic-link sign-in endpoints.
+func LoginRoutes(authRoutes *gin.RouterGroup) {
+	authRoutes.POST("/email/login/request", requestMagicLink)
+	authRoutes.POST("/email/login/consume", consumeMagicLink)
+}
+
+func requestMagicLink(c *gin.Context) {
+	var req struct {
+		Email string `json:"email"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.Email) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "email is required"})
+		return
+	}
+	if !strings.Contains(req.Email, "@") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email address"})
+		return
+	}
+	result, err := libauth.PrepareMagicLink(c, strings.TrimSpace(req.Email))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	// Always 200 – avoids leaking whether the email is registered.
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	if result != nil {
+		loginLink := buildMagicLinkURL(c, result.Token)
+		go libauth.SendMagicLinkNotification(result.Email, result.UserName, loginLink)
+	}
+}
+
+func consumeMagicLink(c *gin.Context) {
+	var req struct {
+		Token string `json:"token"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || req.Token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "token is required"})
+		return
+	}
+	userID, err := libauth.ConsumeMagicLink(c, req.Token)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := middleware.SetSessionCookie(c, userID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func buildMagicLinkURL(c *gin.Context, token string) string {
+	scheme := c.GetHeader("X-Forwarded-Proto")
+	if scheme == "" {
+		if c.Request.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	host := c.GetHeader("X-Forwarded-Host")
+	if host == "" {
+		host = c.Request.Host
+	}
+	return scheme + "://" + host + "/app?magic_token=" + url.QueryEscape(token)
+}

--- a/api/auth/passkeys/admin.go
+++ b/api/auth/passkeys/admin.go
@@ -61,5 +61,3 @@ func adminListUserPasskeys(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, libauth.PasskeyListMap(rows, nil))
 }
-
-

--- a/api/auth/passkeys/admin.go
+++ b/api/auth/passkeys/admin.go
@@ -1,0 +1,65 @@
+package passkeys
+
+import (
+	"net/http"
+
+	"reesource-tracker/api/middleware"
+	libauth "reesource-tracker/lib/auth"
+	"reesource-tracker/lib/database"
+	id_helper "reesource-tracker/lib/id_helper"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AdminRoutes registers admin-only passkey endpoints under the provided /admin group.
+func AdminRoutes(admin *gin.RouterGroup) {
+	admin.GET("/users/:user_id/passkeys", adminListUserPasskeys)
+	admin.POST("/users/:user_id/passkeys/revoke-all", middleware.RequireConfirmedAction(), adminRevokeAllPasskeys)
+	admin.POST("/passkeys/:credential_id/revoke", middleware.RequireConfirmedAction(), adminRevokePasskey)
+}
+
+func adminRevokeAllPasskeys(c *gin.Context) {
+	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	if err := database.Connection.RevokeAllPasskeysForUser(c, uid); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	actor, _ := middleware.CurrentUserID(c)
+	_ = libauth.AuditLog(c, &actor, "passkeys_revoked_all", "user", c.Param("user_id"), map[string]any{})
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func adminRevokePasskey(c *gin.Context) {
+	credentialID, credentialIDHex, err := libauth.DecodeCredentialID(c.Param("credential_id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid credential_id"})
+		return
+	}
+	if err := database.Connection.RevokePasskey(c, credentialID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	actor, _ := middleware.CurrentUserID(c)
+	_ = libauth.AuditLog(c, &actor, "passkey_revoked", "passkey", credentialIDHex, map[string]any{"scope": "admin"})
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func adminListUserPasskeys(c *gin.Context) {
+	uid, msg, ok := id_helper.MustParseAndMarshalUUID(c.Param("user_id"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msg})
+		return
+	}
+	rows, err := database.Connection.ListPasskeysByUser(c, uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, libauth.PasskeyListMap(rows, nil))
+}
+
+

--- a/api/auth/passkeys/passkeys.go
+++ b/api/auth/passkeys/passkeys.go
@@ -1,0 +1,134 @@
+package passkeys
+
+import (
+	"io"
+	"net/http"
+
+	"reesource-tracker/api/middleware"
+	libauth "reesource-tracker/lib/auth"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Routes registers the unauthenticated passkey registration and login endpoints.
+func Routes(authRoutes *gin.RouterGroup) {
+	authRoutes.POST("/register/begin", beginRegistration)
+	authRoutes.POST("/register/finish", finishRegistration)
+	authRoutes.POST("/login/begin", beginLogin)
+	authRoutes.POST("/login/finish", finishLogin)
+}
+
+func beginRegistration(c *gin.Context) {
+	var req struct {
+		AssignmentToken string `json:"assignment_token"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	res, err := libauth.BeginRegistration(c, req.AssignmentToken)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"challenge_token": res.ChallengeToken,
+		"challenge":       res.Challenge,
+		"user_id":         res.UserID,
+		"user_name":       res.UserName,
+	})
+}
+
+func finishRegistration(c *gin.Context) {
+	var req struct {
+		ChallengeToken string   `json:"challenge_token"`
+		Challenge      string   `json:"challenge"`
+		CredentialID   string   `json:"credential_id"`
+		PublicKey      string   `json:"public_key"`
+		Label          string   `json:"label"`
+		Transports     []string `json:"transports"`
+		ClientDataJSON string   `json:"client_data_json"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	credentialID, err := libauth.DecodeBase64(req.CredentialID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid credential_id"})
+		return
+	}
+	userID, err := libauth.FinishRegistration(c, libauth.FinishRegistrationInput{
+		ChallengeToken: req.ChallengeToken,
+		Challenge:      req.Challenge,
+		CredentialID:   req.CredentialID,
+		PublicKey:      req.PublicKey,
+		Label:          req.Label,
+		Transports:     req.Transports,
+		ClientDataJSON: req.ClientDataJSON,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := middleware.SetSessionCookieWithCredential(c, userID, credentialID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func beginLogin(c *gin.Context) {
+	var req struct {
+		UserID string `json:"user_id"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil && err != io.EOF {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	res, err := libauth.BeginLogin(c, req.UserID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"challenge_token": res.ChallengeToken, "challenge": res.Challenge})
+}
+
+func finishLogin(c *gin.Context) {
+	var req struct {
+		ChallengeToken    string `json:"challenge_token"`
+		Challenge         string `json:"challenge"`
+		CredentialID      string `json:"credential_id"`
+		SignCounter       int64  `json:"sign_counter"`
+		ClientDataJSON    string `json:"client_data_json"`
+		AuthenticatorData string `json:"authenticator_data"`
+		Signature         string `json:"signature"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	credentialID, err := libauth.DecodeBase64(req.CredentialID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid credential_id"})
+		return
+	}
+	userID, err := libauth.FinishLogin(c, libauth.FinishLoginInput{
+		ChallengeToken:    req.ChallengeToken,
+		Challenge:         req.Challenge,
+		CredentialID:      req.CredentialID,
+		SignCounter:       req.SignCounter,
+		ClientDataJSON:    req.ClientDataJSON,
+		AuthenticatorData: req.AuthenticatorData,
+		Signature:         req.Signature,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := middleware.SetSessionCookieWithCredential(c, userID, credentialID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/api/auth/passkeys/self.go
+++ b/api/auth/passkeys/self.go
@@ -1,0 +1,69 @@
+package passkeys
+
+import (
+	"bytes"
+	"database/sql"
+	"errors"
+	"net/http"
+
+	"reesource-tracker/api/middleware"
+	libauth "reesource-tracker/lib/auth"
+	"reesource-tracker/lib/database"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SelfRoutes registers authenticated routes for the current user's passkeys
+// under the provided /self group.
+func SelfRoutes(self *gin.RouterGroup) {
+	self.GET("/passkeys", listSelfPasskeys)
+	self.POST("/passkeys/:credential_id/revoke", middleware.RequireConfirmedAction(), revokeSelfPasskey)
+}
+
+func listSelfPasskeys(c *gin.Context) {
+	userID, _ := middleware.CurrentUserID(c)
+	rows, err := database.Connection.ListPasskeysByUser(c, userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	activeCredentialID, _ := middleware.CurrentCredentialID(c)
+	c.JSON(http.StatusOK, libauth.PasskeyListMap(rows, activeCredentialID))
+}
+
+func revokeSelfPasskey(c *gin.Context) {
+	userID, _ := middleware.CurrentUserID(c)
+	credentialID, credentialIDHex, err := libauth.DecodeCredentialID(c.Param("credential_id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid credential_id"})
+		return
+	}
+	passkey, err := database.Connection.GetPasskeyByCredentialID(c, credentialID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "passkey not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if !bytes.Equal(passkey.UserID, userID) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+	activeCredentialID, ok := middleware.CurrentCredentialID(c)
+	if !ok {
+		c.JSON(http.StatusForbidden, gin.H{"error": "reauthentication required before removing passkeys"})
+		return
+	}
+	if bytes.Equal(activeCredentialID, credentialID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "cannot remove the passkey used by your current session"})
+		return
+	}
+	if err := database.Connection.RevokePasskey(c, credentialID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	_ = libauth.AuditLog(c, &userID, "passkey_revoked", "passkey", credentialIDHex, map[string]any{"scope": "self"})
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -6,6 +6,7 @@
     import { Base64UUIDToString } from '$lib/components/id_helper';
     import { Button } from '$lib/components/ui/button';
     import { Toaster } from '$lib/components/ui/sonner/index.js';
+    import { toast } from 'svelte-sonner';
     import * as Tabs from '$lib/components/ui/tabs';
     import ManageRegistrationsDialog from '$lib/components/user/manage_registrations_dialog.svelte';
 
@@ -116,6 +117,25 @@
     }
 
     onMount(async () => {
+        // Consume a magic sign-in token before checking session state.
+        const initParams = new URLSearchParams(window.location.search);
+        const magicToken = initParams.get('magic_token');
+        let magicTokenFailed = false;
+        if (magicToken) {
+            const cleanUrl = new URL(window.location.href);
+            cleanUrl.searchParams.delete('magic_token');
+            window.history.replaceState({}, '', cleanUrl.toString());
+
+            const res = await fetch('/api/auth/email/login/consume', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ token: magicToken }),
+            });
+            if (!res.ok) {
+                magicTokenFailed = true;
+            }
+        }
+
         await refreshAuthState();
 
         if (window.location.search.includes('sample')) {
@@ -135,6 +155,10 @@
         }
 
         authReady = true;
+
+        if (magicTokenFailed) {
+            toast.error('Sign-in link was invalid or has already been used.');
+        }
     });
 
     $effect(() => {

--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
     import { onMount } from 'svelte';
+    import { toast } from 'svelte-sonner';
 
     import { AppStore, UpdateAppStore } from '$lib/components/app_store';
     import UserMenu from '$lib/components/auth/user_menu.svelte';
     import { Base64UUIDToString } from '$lib/components/id_helper';
     import { Button } from '$lib/components/ui/button';
     import { Toaster } from '$lib/components/ui/sonner/index.js';
-    import { toast } from 'svelte-sonner';
     import * as Tabs from '$lib/components/ui/tabs';
     import ManageRegistrationsDialog from '$lib/components/user/manage_registrations_dialog.svelte';
 

--- a/client/src/lib/auth/webauthn.ts
+++ b/client/src/lib/auth/webauthn.ts
@@ -106,7 +106,9 @@ export async function createPasskeyCredential(
         credentialID: bytesToBase64Url(new Uint8Array(result.rawId)),
         publicKey: bytesToBase64Url(new Uint8Array(publicKeyBuffer)),
         transports: response.getTransports?.() ?? ['internal'],
-        clientDataJSON: bytesToBase64Url(new Uint8Array(response.clientDataJSON)),
+        clientDataJSON: bytesToBase64Url(
+            new Uint8Array(response.clientDataJSON),
+        ),
     };
 }
 

--- a/client/src/lib/components/user/manage_registrations_dialog.svelte
+++ b/client/src/lib/components/user/manage_registrations_dialog.svelte
@@ -19,6 +19,12 @@
         isCurrentSession: boolean;
     };
 
+    type RegisteredEmail = {
+        id: number;
+        email: string;
+        createdAt: string;
+    };
+
     let {
         open = $bindable(false),
         userId = '',
@@ -33,6 +39,9 @@
 
     let registrationLink = $state<RegistrationLink | null>(null);
     let registeredPasskeys = $state<RegisteredPasskey[]>([]);
+    let registeredEmails = $state<RegisteredEmail[]>([]);
+    let newEmail = $state('');
+    let emailWorking = $state(false);
 
     let confirmOpen = $state(false);
     let confirmTitle = $state('Confirm Action');
@@ -62,6 +71,18 @@
         return useAdminEndpoints
             ? `/api/auth/admin/passkeys/${credentialId}/revoke`
             : `/api/auth/self/passkeys/${credentialId}/revoke`;
+    }
+
+    function emailsEndpoint(): string {
+        return useAdminEndpoints
+            ? `/api/auth/admin/users/${userId}/emails`
+            : '/api/auth/self/emails';
+    }
+
+    function removeEmailEndpoint(emailId: number): string {
+        return useAdminEndpoints
+            ? `/api/auth/admin/users/${userId}/emails/${emailId}/remove`
+            : `/api/auth/self/emails/${emailId}/remove`;
     }
 
     function openConfirm(
@@ -200,6 +221,80 @@
         }
     }
 
+    async function loadEmails() {
+        if (!hasTargetUser()) {
+            return;
+        }
+
+        const res = await fetch(emailsEndpoint());
+        if (!res.ok) {
+            return;
+        }
+
+        const data = await res.json();
+        registeredEmails = Array.isArray(data)
+            ? data
+                  .filter((e) => typeof e.email === 'string')
+                  .map((e) => ({
+                      id: Number(e.id) || 0,
+                      email: e.email as string,
+                      createdAt:
+                          typeof e.created_at === 'string'
+                              ? e.created_at
+                              : '',
+                  }))
+            : [];
+    }
+
+    async function addEmail() {
+        if (!hasTargetUser() || emailWorking || !newEmail.trim()) {
+            return;
+        }
+        emailWorking = true;
+        try {
+            const res = await fetch(emailsEndpoint(), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: newEmail.trim() }),
+            });
+            if (!res.ok) {
+                toast.error('Failed to add email address.');
+                return;
+            }
+            newEmail = '';
+            await loadEmails();
+            toast.success('Email address added.');
+        } finally {
+            emailWorking = false;
+        }
+    }
+
+    async function removeEmail(emailId: number, emailAddr: string) {
+        if (!hasTargetUser()) {
+            return;
+        }
+
+        openConfirm(
+            'Remove Email Address',
+            `Remove ${emailAddr} from ${userLabel || userId}?`,
+            async () => {
+                const res = await fetch(removeEmailEndpoint(emailId), {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Confirm-Action': 'confirm',
+                    },
+                });
+                if (!res.ok) {
+                    toast.error('Failed to remove email address.');
+                    return;
+                }
+                await loadEmails();
+                toast.success('Email address removed.');
+            },
+        );
+    }
+
     async function revokePasskeyRegistration(credentialId: string) {
         if (!hasTargetUser()) {
             return;
@@ -258,6 +353,7 @@
         loadedState = state;
         void loadRegistrationLink();
         void loadRegisteredPasskeys();
+        void loadEmails();
     });
 
     $effect(() => {
@@ -268,6 +364,8 @@
         loadedState = '';
         registrationLink = null;
         registeredPasskeys = [];
+        registeredEmails = [];
+        newEmail = '';
     });
 </script>
 
@@ -372,6 +470,48 @@
                         No active passkey registrations.
                     </div>
                 {/if}
+            </div>
+
+            <div class="space-y-2 border rounded-md p-3">
+                <div class="text-sm font-medium">Email Addresses</div>
+                {#if registeredEmails.length}
+                    {#each registeredEmails as entry (entry.id)}
+                        <div class="border rounded p-2 text-xs space-y-1">
+                            <div class="font-medium break-all">{entry.email}</div>
+                            <div class="text-muted-foreground">
+                                Added: {formatPasskeyCreatedAt(entry.createdAt)}
+                            </div>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="destructive"
+                                onclick={() => removeEmail(entry.id, entry.email)}>
+                                Remove
+                            </Button>
+                        </div>
+                    {/each}
+                {:else}
+                    <div class="text-xs text-muted-foreground">
+                        No email addresses registered.
+                    </div>
+                {/if}
+                <div class="flex gap-2 pt-1">
+                    <Input
+                        type="email"
+                        placeholder="Add email address"
+                        bind:value={newEmail}
+                        disabled={emailWorking}
+                        onkeydown={(e) => {
+                            if (e.key === 'Enter') addEmail();
+                        }} />
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled={emailWorking || !newEmail.trim()}
+                        onclick={addEmail}>
+                        Add
+                    </Button>
+                </div>
             </div>
         </div>
     </Dialog.Content>

--- a/client/src/lib/components/user/manage_registrations_dialog.svelte
+++ b/client/src/lib/components/user/manage_registrations_dialog.svelte
@@ -239,9 +239,7 @@
                       id: Number(e.id) || 0,
                       email: e.email as string,
                       createdAt:
-                          typeof e.created_at === 'string'
-                              ? e.created_at
-                              : '',
+                          typeof e.created_at === 'string' ? e.created_at : '',
                   }))
             : [];
     }
@@ -477,7 +475,8 @@
                 {#if registeredEmails.length}
                     {#each registeredEmails as entry (entry.id)}
                         <div class="border rounded p-2 text-xs space-y-1">
-                            <div class="font-medium break-all">{entry.email}</div>
+                            <div class="font-medium break-all"
+                                >{entry.email}</div>
                             <div class="text-muted-foreground">
                                 Added: {formatPasskeyCreatedAt(entry.createdAt)}
                             </div>
@@ -485,7 +484,8 @@
                                 type="button"
                                 size="sm"
                                 variant="destructive"
-                                onclick={() => removeEmail(entry.id, entry.email)}>
+                                onclick={() =>
+                                    removeEmail(entry.id, entry.email)}>
                                 Remove
                             </Button>
                         </div>

--- a/client/src/views/login.svelte
+++ b/client/src/views/login.svelte
@@ -122,8 +122,7 @@
                         </div>
                         <div
                             class="relative flex justify-center text-xs uppercase">
-                            <span
-                                class="bg-card px-2 text-muted-foreground"
+                            <span class="bg-card px-2 text-muted-foreground"
                                 >or</span>
                         </div>
                     </div>

--- a/client/src/views/login.svelte
+++ b/client/src/views/login.svelte
@@ -1,14 +1,31 @@
 <script lang="ts">
-    import { createEventDispatcher } from 'svelte';
+    import { createEventDispatcher, onMount } from 'svelte';
     import { toast } from 'svelte-sonner';
 
     import { getPasskeyAssertion } from '$lib/auth/webauthn';
     import { Button } from '$lib/components/ui/button';
     import * as Card from '$lib/components/ui/card';
+    import { Input } from '$lib/components/ui/input';
 
     const dispatch = createEventDispatcher<{ authenticated: void }>();
 
     let working = $state(false);
+    let magicLinkEnabled = $state(false);
+    let emailMode = $state(false);
+    let email = $state('');
+    let emailSent = $state(false);
+
+    onMount(async () => {
+        try {
+            const res = await fetch('/api/auth/features');
+            if (res.ok) {
+                const data = await res.json();
+                magicLinkEnabled = !!data.magic_links_enabled;
+            }
+        } catch {
+            // passkey-only mode if features endpoint unavailable
+        }
+    });
 
     async function signIn() {
         if (working) {
@@ -60,6 +77,31 @@
             working = false;
         }
     }
+
+    async function requestEmailLink() {
+        if (working || !email.trim()) {
+            return;
+        }
+        working = true;
+        try {
+            const res = await fetch('/api/auth/email/login/request', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: email.trim() }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                throw new Error(data.error || 'Failed to send sign-in link');
+            }
+            emailSent = true;
+        } catch (error) {
+            const message =
+                error instanceof Error ? error.message : String(error);
+            toast.error(message);
+        } finally {
+            working = false;
+        }
+    }
 </script>
 
 <div class="w-full h-full flex items-center justify-center p-4">
@@ -69,9 +111,81 @@
             <Card.Description>Access your workspace.</Card.Description>
         </Card.Header>
         <Card.Content class="space-y-4">
-            <Button class="w-full" onclick={signIn} disabled={working}>
-                {working ? 'Signing In...' : 'Continue'}
-            </Button>
+            {#if !emailMode}
+                <Button class="w-full" onclick={signIn} disabled={working}>
+                    {working ? 'Signing In...' : 'Continue with Passkey'}
+                </Button>
+                {#if magicLinkEnabled}
+                    <div class="relative">
+                        <div class="absolute inset-0 flex items-center">
+                            <span class="w-full border-t"></span>
+                        </div>
+                        <div
+                            class="relative flex justify-center text-xs uppercase">
+                            <span
+                                class="bg-card px-2 text-muted-foreground"
+                                >or</span>
+                        </div>
+                    </div>
+                    <Button
+                        variant="outline"
+                        class="w-full"
+                        onclick={() => {
+                            emailMode = true;
+                            emailSent = false;
+                            email = '';
+                        }}>
+                        Sign in with Email Link
+                    </Button>
+                {/if}
+            {:else if emailSent}
+                <p class="text-sm text-center text-muted-foreground">
+                    If an account is registered with that address, a sign-in
+                    link has been sent. Check your inbox.
+                </p>
+                <Button
+                    variant="outline"
+                    class="w-full"
+                    onclick={() => {
+                        emailSent = false;
+                        email = '';
+                    }}>
+                    Send Another Link
+                </Button>
+                <Button
+                    variant="ghost"
+                    class="w-full"
+                    onclick={() => {
+                        emailMode = false;
+                        emailSent = false;
+                    }}>
+                    Back to Passkey Sign-In
+                </Button>
+            {:else}
+                <Input
+                    type="email"
+                    placeholder="you@example.com"
+                    bind:value={email}
+                    disabled={working}
+                    onkeydown={(e) => {
+                        if (e.key === 'Enter') requestEmailLink();
+                    }} />
+                <Button
+                    class="w-full"
+                    onclick={requestEmailLink}
+                    disabled={working || !email.trim()}>
+                    {working ? 'Sending...' : 'Send Sign-In Link'}
+                </Button>
+                <Button
+                    variant="ghost"
+                    class="w-full"
+                    onclick={() => {
+                        emailMode = false;
+                        email = '';
+                    }}>
+                    Back to Passkey Sign-In
+                </Button>
+            {/if}
         </Card.Content>
     </Card.Root>
 </div>

--- a/client/src/views/passkey_assignment.svelte
+++ b/client/src/views/passkey_assignment.svelte
@@ -5,6 +5,7 @@
     import { createPasskeyCredential } from '$lib/auth/webauthn';
     import { Button } from '$lib/components/ui/button';
     import * as Card from '$lib/components/ui/card';
+    import { Input } from '$lib/components/ui/input';
 
     const dispatch = createEventDispatcher<{ completed: void }>();
 
@@ -12,6 +13,9 @@
 
     let token = $state('');
     let working = $state(false);
+    // 'choose' | 'passkey' | 'email'
+    let mode = $state<'choose' | 'passkey' | 'email'>('choose');
+    let email = $state('');
 
     $effect(() => {
         if (!token && assignmentToken) {
@@ -20,10 +24,7 @@
     });
 
     async function assignPasskey() {
-        if (!token || working) {
-            return;
-        }
-
+        if (!token || working) return;
         working = true;
         try {
             const beginRes = await fetch('/api/auth/register/begin', {
@@ -33,18 +34,15 @@
             });
             if (!beginRes.ok) {
                 throw new Error(
-                    (await beginRes.json()).error ||
-                        'Registration begin failed',
+                    (await beginRes.json()).error || 'Registration begin failed',
                 );
             }
             const begin = await beginRes.json();
-
             const credential = await createPasskeyCredential(
                 begin.challenge,
                 begin.user_id,
                 begin.user_name || begin.user_id,
             );
-
             const finishRes = await fetch('/api/auth/register/finish', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -63,13 +61,40 @@
                     (await finishRes.json()).error || 'Registration failed',
                 );
             }
-
             toast.success('Passkey assigned successfully.');
             dispatch('completed');
         } catch (error) {
             const message =
                 error instanceof Error ? error.message : String(error);
             toast.error(`Passkey assignment failed: ${message}`);
+        } finally {
+            working = false;
+        }
+    }
+
+    async function assignEmail() {
+        if (!token || !email.trim() || working) return;
+        working = true;
+        try {
+            const res = await fetch('/api/auth/email/register', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    assignment_token: token,
+                    email: email.trim(),
+                }),
+            });
+            if (!res.ok) {
+                throw new Error(
+                    (await res.json()).error || 'Email registration failed',
+                );
+            }
+            toast.success('Email address registered. Use it to sign in with a magic link.');
+            dispatch('completed');
+        } catch (error) {
+            const message =
+                error instanceof Error ? error.message : String(error);
+            toast.error(`Email registration failed: ${message}`);
         } finally {
             working = false;
         }
@@ -81,16 +106,69 @@
         <Card.Header>
             <Card.Title>Finish Account Setup</Card.Title>
             <Card.Description>
-                Set up sign-in for this account.
+                Choose how you want to sign in.
             </Card.Description>
         </Card.Header>
         <Card.Content class="space-y-4">
-            <Button
-                class="w-full"
-                onclick={assignPasskey}
-                disabled={working || !token}>
-                {working ? 'Setting Up Sign-In...' : 'Set Up Sign-In'}
-            </Button>
+            {#if mode === 'choose'}
+                <Button
+                    class="w-full"
+                    onclick={() => (mode = 'passkey')}
+                    disabled={working || !token}>
+                    Set Up Passkey
+                </Button>
+                <Button
+                    variant="outline"
+                    class="w-full"
+                    onclick={() => (mode = 'email')}
+                    disabled={working || !token}>
+                    Register Email Address
+                </Button>
+            {:else if mode === 'passkey'}
+                <p class="text-sm text-muted-foreground">
+                    Your browser will prompt you to create a passkey for this
+                    device.
+                </p>
+                <Button
+                    class="w-full"
+                    onclick={assignPasskey}
+                    disabled={working || !token}>
+                    {working ? 'Setting Up...' : 'Create Passkey'}
+                </Button>
+                <Button
+                    variant="ghost"
+                    class="w-full"
+                    onclick={() => (mode = 'choose')}
+                    disabled={working}>
+                    Back
+                </Button>
+            {:else}
+                <p class="text-sm text-muted-foreground">
+                    Enter an email address. You will receive a sign-in link each
+                    time you want to log in.
+                </p>
+                <Input
+                    type="email"
+                    placeholder="you@example.com"
+                    bind:value={email}
+                    disabled={working}
+                    onkeydown={(e) => {
+                        if (e.key === 'Enter') assignEmail();
+                    }} />
+                <Button
+                    class="w-full"
+                    onclick={assignEmail}
+                    disabled={working || !email.trim() || !token}>
+                    {working ? 'Registering...' : 'Register Email'}
+                </Button>
+                <Button
+                    variant="ghost"
+                    class="w-full"
+                    onclick={() => (mode = 'choose')}
+                    disabled={working}>
+                    Back
+                </Button>
+            {/if}
         </Card.Content>
     </Card.Root>
 </div>

--- a/client/src/views/passkey_assignment.svelte
+++ b/client/src/views/passkey_assignment.svelte
@@ -34,7 +34,8 @@
             });
             if (!beginRes.ok) {
                 throw new Error(
-                    (await beginRes.json()).error || 'Registration begin failed',
+                    (await beginRes.json()).error ||
+                        'Registration begin failed',
                 );
             }
             const begin = await beginRes.json();
@@ -89,7 +90,9 @@
                     (await res.json()).error || 'Email registration failed',
                 );
             }
-            toast.success('Email address registered. Use it to sign in with a magic link.');
+            toast.success(
+                'Email address registered. Use it to sign in with a magic link.',
+            );
             dispatch('completed');
         } catch (error) {
             const message =
@@ -105,9 +108,7 @@
     <Card.Root class="w-full max-w-lg">
         <Card.Header>
             <Card.Title>Finish Account Setup</Card.Title>
-            <Card.Description>
-                Choose how you want to sign in.
-            </Card.Description>
+            <Card.Description>Choose how you want to sign in.</Card.Description>
         </Card.Header>
         <Card.Content class="space-y-4">
             {#if mode === 'choose'}

--- a/database/migrations/0004_magic_links.down.sql
+++ b/database/migrations/0004_magic_links.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS magic_links;
+DROP TABLE IF EXISTS user_emails;

--- a/database/migrations/0004_magic_links.up.sql
+++ b/database/migrations/0004_magic_links.up.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS user_emails (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BYTEA NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (user_id, email)
+);
+
+CREATE TABLE IF NOT EXISTS magic_links (
+    id BIGSERIAL PRIMARY KEY,
+    token_hash TEXT NOT NULL UNIQUE,
+    user_id BYTEA NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL,
+    used_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_emails_user_id ON user_emails(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_emails_email ON user_emails(email);
+CREATE INDEX IF NOT EXISTS idx_magic_links_user_id ON magic_links(user_id);

--- a/database/query.sql
+++ b/database/query.sql
@@ -429,3 +429,56 @@ WHERE role = 'admin';
 
 -- name: EnableAdminRemovalOverride :exec
 SELECT set_config('app.allow_remove_last_admin', 'on', true);
+
+-- name: InsertUserEmail :exec
+INSERT INTO user_emails (user_id, email)
+VALUES ($1, $2)
+ON CONFLICT (user_id, email) DO NOTHING;
+
+-- name: DeleteUserEmail :exec
+DELETE FROM user_emails
+WHERE user_id = $1
+    AND email = $2;
+
+-- name: ListUserEmails :many
+SELECT id, user_id, email, created_at
+FROM user_emails
+WHERE user_id = $1
+ORDER BY created_at ASC;
+
+-- name: GetUserByEmail :one
+SELECT users.id, users.name
+FROM users
+INNER JOIN user_emails ON user_emails.user_id = users.id
+WHERE LOWER(user_emails.email) = LOWER($1)
+LIMIT 1;
+
+-- name: CreateMagicLink :one
+INSERT INTO magic_links (token_hash, user_id, expires_at)
+VALUES ($1, $2, $3)
+RETURNING id, token_hash, user_id, created_at, expires_at, used_at;
+
+-- name: GetActiveMagicLinkByTokenHash :one
+SELECT id, token_hash, user_id, created_at, expires_at, used_at
+FROM magic_links
+WHERE token_hash = $1
+    AND used_at IS NULL
+    AND expires_at > NOW();
+
+-- name: ConsumeMagicLink :exec
+UPDATE magic_links
+SET used_at = NOW()
+WHERE id = $1
+    AND used_at IS NULL;
+
+-- name: DeleteMagicLinksForUser :exec
+DELETE FROM magic_links
+WHERE user_id = $1
+    AND used_at IS NULL;
+
+-- name: GetLatestMagicLinkForUser :one
+SELECT id, token_hash, user_id, created_at, expires_at, used_at
+FROM magic_links
+WHERE user_id = $1
+ORDER BY created_at DESC
+LIMIT 1;

--- a/lib/auth/magic_link.go
+++ b/lib/auth/magic_link.go
@@ -1,0 +1,139 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"reesource-tracker/lib/database"
+	id_helper "reesource-tracker/lib/id_helper"
+)
+
+const (
+	MagicLinkLifetime = 10 * time.Minute
+	MagicLinkCooldown = 30 * time.Second
+)
+
+// MagicLinkEnabled reports whether the magic link feature is configured.
+func MagicLinkEnabled() bool {
+	return os.Getenv("MAGIC_LINK_WEBHOOK_URL") != ""
+}
+
+// MagicLinkRequest holds the raw token and user details produced by
+// PrepareMagicLink, ready for the caller to build the login URL and dispatch
+// the notification.
+type MagicLinkRequest struct {
+	Token    string
+	UserName string
+	Email    string
+}
+
+// PrepareMagicLink looks up the user by email, enforces the per-user rate
+// limit, discards any existing pending links, creates a new one and returns
+// the raw token together with user details.
+//
+// Returns nil (no error) when the email address is not registered; the caller
+// should respond with HTTP 200 without indicating whether the email exists.
+func PrepareMagicLink(ctx context.Context, email string) (*MagicLinkRequest, error) {
+	if !MagicLinkEnabled() {
+		return nil, errors.New("magic link sign-in is not enabled")
+	}
+
+	user, err := database.Connection.GetUserByEmail(ctx, email)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil // unknown email – silently ignore
+		}
+		return nil, err
+	}
+
+	// Enforce rate limit using the most recently created link (used or not).
+	existing, err := database.Connection.GetLatestMagicLinkForUser(ctx, user.ID)
+	if err == nil {
+		cooldownEnd := existing.CreatedAt.Add(MagicLinkCooldown)
+		if time.Now().Before(cooldownEnd) {
+			remaining := time.Until(cooldownEnd).Round(time.Second)
+			return nil, fmt.Errorf("please wait %s before requesting another sign-in link", remaining)
+		}
+	}
+
+	// Discard any unexpired pending links for this user.
+	_ = database.Connection.DeleteMagicLinksForUser(ctx, user.ID)
+
+	token, err := RandomHex(32)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = database.Connection.CreateMagicLink(ctx, database.CreateMagicLinkParams{
+		TokenHash: HashToken(token),
+		UserID:    user.ID,
+		ExpiresAt: time.Now().Add(MagicLinkLifetime),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	userIDStr, _ := id_helper.UnmarshalUUID(user.ID)
+	_ = AuditLog(ctx, nil, "magic_link_requested", "user", userIDStr, map[string]any{"email": email})
+
+	return &MagicLinkRequest{Token: token, UserName: user.Name, Email: email}, nil
+}
+
+// SendMagicLinkNotification posts the magic link payload to the configured
+// webhook URL. It is intended to be called in a goroutine so the HTTP
+// response is not delayed by the outbound webhook call.
+func SendMagicLinkNotification(email, userName, loginLink string) {
+	webhookURL := os.Getenv("MAGIC_LINK_WEBHOOK_URL")
+	if webhookURL == "" {
+		return
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"user_email": email,
+		"user_name":  userName,
+		"login_link": loginLink,
+	})
+	if err != nil {
+		return
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Post(webhookURL, "application/json", bytes.NewReader(body))
+
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}
+
+// ConsumeMagicLink validates the raw token, marks the link as used and
+// returns the associated user ID so the caller can establish a session.
+func ConsumeMagicLink(ctx context.Context, token string) ([]byte, error) {
+	if !MagicLinkEnabled() {
+		return nil, errors.New("magic link sign-in is not enabled")
+	}
+
+	link, err := database.Connection.GetActiveMagicLinkByTokenHash(ctx, HashToken(token))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("invalid or expired sign-in link")
+		}
+		return nil, err
+	}
+
+	if err := database.Connection.ConsumeMagicLink(ctx, link.ID); err != nil {
+		return nil, err
+	}
+
+	userIDStr, _ := id_helper.UnmarshalUUID(link.UserID)
+	_ = AuditLog(ctx, &link.UserID, "magic_link_consumed", "user", userIDStr, map[string]any{})
+
+	return link.UserID, nil
+}

--- a/lib/auth/method.go
+++ b/lib/auth/method.go
@@ -1,0 +1,25 @@
+package auth
+
+import "github.com/gin-gonic/gin"
+
+// AuthMethod represents a pluggable sign-in credential type (e.g. passkeys,
+// email magic links). Each method registers its own unauthenticated sign-in
+// routes, authenticated self-management routes, and admin management routes.
+//
+// Implementations live under api/auth/<method>/ so that each auth method is
+// fully self-contained. The central auth.Routes() wiring file calls these
+// methods in sequence; adding a new auth method only requires implementing
+// this interface and registering it there.
+type AuthMethod interface {
+	// Routes registers publicly accessible endpoints – sign-in flows that
+	// do not require an existing session (e.g. login/begin, login/consume).
+	Routes(authRoutes *gin.RouterGroup)
+
+	// SelfRoutes registers authenticated endpoints that allow the currently
+	// signed-in user to manage their own credentials (list, add, remove).
+	SelfRoutes(self *gin.RouterGroup)
+
+	// AdminRoutes registers admin-only endpoints for managing any user's
+	// credentials.
+	AdminRoutes(admin *gin.RouterGroup)
+}

--- a/lib/auth/response.go
+++ b/lib/auth/response.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/hex"
+	"net/http"
+	"net/url"
+
+	"reesource-tracker/lib/database"
+)
+
+// DecodeCredentialID parses a credential ID from a raw string that may be
+// hex-encoded or base64url-encoded. Returns the raw bytes and the canonical
+// hex string.
+func DecodeCredentialID(raw string) ([]byte, string, error) {
+	id, err := hex.DecodeString(raw)
+	if err == nil {
+		return id, raw, nil
+	}
+	id, err = DecodeBase64(raw)
+	if err != nil {
+		return nil, "", err
+	}
+	return id, hex.EncodeToString(id), nil
+}
+
+// BuildAssignmentURL constructs the full assignment link URL from an incoming
+// HTTP request and the raw token. It respects X-Forwarded-Proto and
+// X-Forwarded-Host proxy headers.
+func BuildAssignmentURL(r *http.Request, token string) string {
+	scheme := r.Header.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	return scheme + "://" + host + "/app?assignment_token=" + url.QueryEscape(token)
+}
+
+// AssignmentLinkMap converts a PasskeyAssignmentLink row to a response map.
+// If rawToken is non-empty, the token and a full assignment URL are included.
+func AssignmentLinkMap(r *http.Request, row database.PasskeyAssignmentLink, rawToken string) map[string]any {
+	res := map[string]any{
+		"link_id": row.ID,
+	}
+	if rawToken != "" {
+		res["assignment_token"] = rawToken
+		res["assignment_url"] = BuildAssignmentURL(r, rawToken)
+	}
+	if row.ExpiresAt.Valid {
+		res["expires_at"] = row.ExpiresAt.Time
+	}
+	return res
+}
+
+// PasskeyListMap converts passkey rows to response maps, filtering out revoked
+// entries and marking the active session credential.
+func PasskeyListMap(rows []database.Passkey, activeCredentialID []byte) []map[string]any {
+	res := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		if row.RevokedAt.Valid {
+			continue
+		}
+		label := ""
+		if row.Label.Valid {
+			label = row.Label.String
+		}
+		res = append(res, map[string]any{
+			"credential_id":      hex.EncodeToString(row.CredentialID),
+			"label":              label,
+			"created_at":         row.CreatedAt,
+			"is_current_session": len(activeCredentialID) > 0 && bytes.Equal(row.CredentialID, activeCredentialID),
+		})
+	}
+	return res
+}

--- a/lib/database/models.go
+++ b/lib/database/models.go
@@ -45,6 +45,15 @@ type Location struct {
 	ParentLocationID sql.Null[[]byte]
 }
 
+type MagicLink struct {
+	ID        int64
+	TokenHash string
+	UserID    []byte
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	UsedAt    sql.NullTime
+}
+
 type Passkey struct {
 	ID           int64
 	CredentialID []byte
@@ -118,6 +127,13 @@ type Tag struct {
 type User struct {
 	ID   []byte
 	Name string
+}
+
+type UserEmail struct {
+	ID        int64
+	UserID    []byte
+	Email     string
+	CreatedAt time.Time
 }
 
 type UserRole struct {

--- a/lib/database/query.sql.go
+++ b/lib/database/query.sql.go
@@ -76,6 +76,18 @@ func (q *Queries) ConsumeAssignmentLink(ctx context.Context, id int64) error {
 	return err
 }
 
+const consumeMagicLink = `-- name: ConsumeMagicLink :exec
+UPDATE magic_links
+SET used_at = NOW()
+WHERE id = $1
+    AND used_at IS NULL
+`
+
+func (q *Queries) ConsumeMagicLink(ctx context.Context, id int64) error {
+	_, err := q.db.ExecContext(ctx, consumeMagicLink, id)
+	return err
+}
+
 const countAdmins = `-- name: CountAdmins :one
 SELECT COUNT(*)
 FROM user_roles
@@ -132,6 +144,32 @@ func (q *Queries) CreateAssignmentLink(ctx context.Context, arg CreateAssignment
 	return i, err
 }
 
+const createMagicLink = `-- name: CreateMagicLink :one
+INSERT INTO magic_links (token_hash, user_id, expires_at)
+VALUES ($1, $2, $3)
+RETURNING id, token_hash, user_id, created_at, expires_at, used_at
+`
+
+type CreateMagicLinkParams struct {
+	TokenHash string
+	UserID    []byte
+	ExpiresAt time.Time
+}
+
+func (q *Queries) CreateMagicLink(ctx context.Context, arg CreateMagicLinkParams) (MagicLink, error) {
+	row := q.db.QueryRowContext(ctx, createMagicLink, arg.TokenHash, arg.UserID, arg.ExpiresAt)
+	var i MagicLink
+	err := row.Scan(
+		&i.ID,
+		&i.TokenHash,
+		&i.UserID,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.UsedAt,
+	)
+	return i, err
+}
+
 const deleteAuditLogsOlderThan = `-- name: DeleteAuditLogsOlderThan :exec
 DELETE FROM audit_logs
 WHERE created_at < $1
@@ -163,6 +201,17 @@ func (q *Queries) DeleteLocationByID(ctx context.Context, id []byte) error {
 	return err
 }
 
+const deleteMagicLinksForUser = `-- name: DeleteMagicLinksForUser :exec
+DELETE FROM magic_links
+WHERE user_id = $1
+    AND used_at IS NULL
+`
+
+func (q *Queries) DeleteMagicLinksForUser(ctx context.Context, userID []byte) error {
+	_, err := q.db.ExecContext(ctx, deleteMagicLinksForUser, userID)
+	return err
+}
+
 const deleteProductByID = `-- name: DeleteProductByID :exec
 DELETE FROM products
 WHERE
@@ -182,6 +231,22 @@ WHERE
 
 func (q *Queries) DeleteUserByID(ctx context.Context, id []byte) error {
 	_, err := q.db.ExecContext(ctx, deleteUserByID, id)
+	return err
+}
+
+const deleteUserEmail = `-- name: DeleteUserEmail :exec
+DELETE FROM user_emails
+WHERE user_id = $1
+    AND email = $2
+`
+
+type DeleteUserEmailParams struct {
+	UserID []byte
+	Email  string
+}
+
+func (q *Queries) DeleteUserEmail(ctx context.Context, arg DeleteUserEmailParams) error {
+	_, err := q.db.ExecContext(ctx, deleteUserEmail, arg.UserID, arg.Email)
 	return err
 }
 
@@ -271,6 +336,28 @@ func (q *Queries) GetActiveBootstrapLink(ctx context.Context) (PasskeyAssignment
 	return i, err
 }
 
+const getActiveMagicLinkByTokenHash = `-- name: GetActiveMagicLinkByTokenHash :one
+SELECT id, token_hash, user_id, created_at, expires_at, used_at
+FROM magic_links
+WHERE token_hash = $1
+    AND used_at IS NULL
+    AND expires_at > NOW()
+`
+
+func (q *Queries) GetActiveMagicLinkByTokenHash(ctx context.Context, tokenHash string) (MagicLink, error) {
+	row := q.db.QueryRowContext(ctx, getActiveMagicLinkByTokenHash, tokenHash)
+	var i MagicLink
+	err := row.Scan(
+		&i.ID,
+		&i.TokenHash,
+		&i.UserID,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.UsedAt,
+	)
+	return i, err
+}
+
 const getActiveStandardAssignmentLinkByUserID = `-- name: GetActiveStandardAssignmentLinkByUserID :one
 SELECT id, token_hash, user_id, created_by_user_id, purpose, created_at, expires_at, consumed_at, revoked_at
 FROM passkey_assignment_links
@@ -319,6 +406,28 @@ func (q *Queries) GetAssignmentLinkByID(ctx context.Context, id int64) (PasskeyA
 		&i.ExpiresAt,
 		&i.ConsumedAt,
 		&i.RevokedAt,
+	)
+	return i, err
+}
+
+const getLatestMagicLinkForUser = `-- name: GetLatestMagicLinkForUser :one
+SELECT id, token_hash, user_id, created_at, expires_at, used_at
+FROM magic_links
+WHERE user_id = $1
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+func (q *Queries) GetLatestMagicLinkForUser(ctx context.Context, userID []byte) (MagicLink, error) {
+	row := q.db.QueryRowContext(ctx, getLatestMagicLinkForUser, userID)
+	var i MagicLink
+	err := row.Scan(
+		&i.ID,
+		&i.TokenHash,
+		&i.UserID,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.UsedAt,
 	)
 	return i, err
 }
@@ -539,6 +648,21 @@ func (q *Queries) GetSampleById(ctx context.Context, id []byte) (Sample, error) 
 	return i, err
 }
 
+const getUserByEmail = `-- name: GetUserByEmail :one
+SELECT users.id, users.name
+FROM users
+INNER JOIN user_emails ON user_emails.user_id = users.id
+WHERE LOWER(user_emails.email) = LOWER($1)
+LIMIT 1
+`
+
+func (q *Queries) GetUserByEmail(ctx context.Context, lower string) (User, error) {
+	row := q.db.QueryRowContext(ctx, getUserByEmail, lower)
+	var i User
+	err := row.Scan(&i.ID, &i.Name)
+	return i, err
+}
+
 const getUserByID = `-- name: GetUserByID :one
 SELECT id, name
 FROM
@@ -743,6 +867,22 @@ func (q *Queries) InsertPasskey(ctx context.Context, arg InsertPasskeyParams) er
 		arg.Column5,
 		arg.Label,
 	)
+	return err
+}
+
+const insertUserEmail = `-- name: InsertUserEmail :exec
+INSERT INTO user_emails (user_id, email)
+VALUES ($1, $2)
+ON CONFLICT (user_id, email) DO NOTHING
+`
+
+type InsertUserEmailParams struct {
+	UserID []byte
+	Email  string
+}
+
+func (q *Queries) InsertUserEmail(ctx context.Context, arg InsertUserEmailParams) error {
+	_, err := q.db.ExecContext(ctx, insertUserEmail, arg.UserID, arg.Email)
 	return err
 }
 
@@ -962,6 +1102,41 @@ func (q *Queries) ListSamples(ctx context.Context) ([]ListSamplesRow, error) {
 			&i.ProductIssue,
 			&i.CurrentModsSummary,
 			&i.OwnerName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUserEmails = `-- name: ListUserEmails :many
+SELECT id, user_id, email, created_at
+FROM user_emails
+WHERE user_id = $1
+ORDER BY created_at ASC
+`
+
+func (q *Queries) ListUserEmails(ctx context.Context, userID []byte) ([]UserEmail, error) {
+	rows, err := q.db.QueryContext(ctx, listUserEmails, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []UserEmail
+	for rows.Next() {
+		var i UserEmail
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.Email,
+			&i.CreatedAt,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Currently, passkey auth does not work in some cases where the passkey cannot be stored on the user's device (i.e. organisational restrictions). This PR adds an alternative method for authentication, by using magic sign on links. It integrates via webhook URL to allow easy integration via tools such as power automate, rather than manual email configuration.

This pull request introduces a comprehensive authentication system to the project, supporting both passkey (WebAuthn) and email (magic link) sign-in methods. It adds modular, well-documented route handlers for assignment links, email management, and initial user bootstrap flows, with clear separation between self-service and admin endpoints. The `README.md` is updated to document environment variables, authentication flows, and the new API surface.

The most important changes are:

**Authentication Features & Documentation**
- Added support for email (magic link) authentication, configurable via the `MAGIC_LINK_WEBHOOK_URL` environment variable, and updated the `README.md` with detailed instructions and API reference for both passkey and email flows. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R105-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R221-R271)
- Expanded the `README.md` with a clearer, more detailed project structure and descriptions of new authentication and API modules.

**API Route Handlers**
- Implemented modular route handlers for assignment links, including self-service (`api/auth/assignmentlinks/self.go`) and admin (`api/auth/assignmentlinks/admin.go`) endpoints for creating, retrieving, and revoking assignment links, as well as listing audit logs. [[1]](diffhunk://#diff-dc3e26324a7e41d6d55e503d6eecccd8b5b8653cc30482fa41785a44942d5accR1-R60) [[2]](diffhunk://#diff-a75c9a771c7f1d2bb383e0087d4d622c422571370ad9673f3ac878eb8a430c65R1-R114)
- Added email management endpoints (`api/auth/emails/emails.go`) for registering emails via assignment links, as well as self-service and admin CRUD operations on user emails, with audit logging.
- Introduced bootstrap endpoints (`api/auth/bootstrap/bootstrap.go`) for initial user setup, allowing creation and selection of bootstrap users and assignment tokens.